### PR TITLE
feat: new event type

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "body-parser": "^1.19.0",
     "dotenv-safe": "^8.2.0",
     "express": "^4.17.1",
-    "latest-version": "^5.1.0",
     "semver": "^6.3.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,22 @@
 # webhook
 
 This project handles the webhooks from `electron/electron` and filters them
-to dispatch only the appropriate ones as `repository_dispatch` events.
+to dispatch only the appropriate ones as `repository_dispatch` events to
+`electron/electronjs.org-new` ("that repo").
+
+These events are used to let that repo know there have been documentation changes.
+
+This repo is subscribed to all `push` events in `electron/electron`. When
+a payload comes it:
+
+1. Checks if there have been changes to the `/docs` folder
+1. Determines in what branch the commit has happend
+1. Sends a `repository_dispatch` with the following information:
+   * `sha`: the SHA of the commit received
+   * `branch`: the branch of the commit, usually something like `15-x-y`
+   * `event_type`:
+     * `doc_changes` if the changes have happened in the major release
+     * `doc_changes_previous` if the changes have happened in a previous major release
 
 ## Local setup
 

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -6,12 +6,15 @@ const {
   getLatestInformation,
   verifyIntegrity,
   sendRepositoryDispatchEvent,
-  getSHAFromTag,
 } = require('../utils/utils');
 
 const OWNER = process.env.OWNER || 'electron';
 const SOURCE_REPO = `electron`;
 const TARGET_REPO = `electronjs.org-new`;
+const EVENT_TYPE = {
+  CURRENT: 'doc_changes',
+  PREVIOUS: 'doc_changes_previous',
+};
 
 /**
  * Verifies there is at least one file added, modified, or removed
@@ -37,23 +40,55 @@ const areFilesInFolderChanged = (pushEvent, folder) => {
 };
 
 /**
+ * Compares 2 refs or branches and returns a boolean indicating
+ * if `current` is from a previous release than `latest`.
+ * @param {string} latest
+ * @param {string} current
+ */
+const getEventType = (latest, current) => {
+  try {
+    const majorRegex = /(?:refs\/heads\/)?(\d+)-x-y/;
+    const [, latestMajor] = majorRegex.exec(latest);
+    const [, currentMajor] = majorRegex.exec(current);
+
+    const parsedLatest = parseInt(latestMajor);
+    const parsedCurrent = parseInt(currentMajor);
+
+    if (parsedCurrent < parsedLatest) {
+      return EVENT_TYPE.PREVIOUS;
+    } else {
+      return EVENT_TYPE.CURRENT;
+    }
+  } catch (e) {
+    return '';
+  }
+};
+
+/**
  * Handler for the GitHub webhook `push` event.
  * @param {import('express').Request} req
  * @param {import('express').Response} res
  */
 const pushHandler = async (req, res) => {
   const { branch } = await getLatestInformation();
-  const ref = `refs/heads/${branch}`;
 
   /** @type {import('@octokit/webhooks-types').PushEvent} */
   const payload = req.body;
 
   if (
-    payload.ref === ref &&
     payload.repository.full_name === `${OWNER}/${SOURCE_REPO}` &&
     areFilesInFolderChanged(payload, 'docs')
   ) {
-    await sendRepositoryDispatchEvent(OWNER, TARGET_REPO, payload.after);
+    const eventType = getEventType(branch, payload.ref);
+    if(!eventType){
+      console.log(`Could not find right version for ${payload.ref}`)
+      return;
+    }
+
+    await sendRepositoryDispatchEvent(OWNER, TARGET_REPO, eventType, {
+      sha: payload.after,
+      branch: payload.ref.replace('refs/heads/', ''),
+    });
   }
 
   return res.status(200).send();
@@ -61,45 +96,14 @@ const pushHandler = async (req, res) => {
 
 /**
  * Handler for the GitHub webhook `release` event.
- * The payload will be processed only if the release
- * payload is for the stable branch.
  * @param {import('express').Request} req
  * @param {import('express').Response} res
  */
 const releaseHandler = async (req, res) => {
+  // We keep this handler for historic reasons but all updates are done via the push event
+
   console.log(`New release payload received`);
-  /** @type {import('@octokit/webhooks-types').ReleaseEvent} */
-  const payload = req.body;
 
-  const { version } = await getLatestInformation();
-
-  // Tags can be v14.0.0-nightly.20210504, v13.0.0-beta.21, v10.4.5, etc.
-  // We only want to process the stable ones, i.e.: v10.4.5
-  // so we remove the initial `v` and we "clean it". If the cleaned
-  // string is the same as before, then it's a stable release.
-  // We also check that the new release is greater or equal than the
-  // published npm version. There can be 30-120s delay between a GitHub
-  // release and an npm one.
-  const tag = payload.release.tag_name.replace(/^v/, '');
-  const isStable = semver.coerce(tag).version === tag;
-
-  console.log(`Version received: ${tag}`);
-  console.log(`Latest version:   ${version}`);
-
-  if (
-    payload.action === 'released' &&
-    !payload.release.draft &&
-    !payload.release.prerelease &&
-    isStable &&
-    semver.gte(tag, version)
-  ) {
-    const sha = await getSHAFromTag(
-      payload.repository.full_name,
-      payload.release.tag_name
-    );
-
-    await sendRepositoryDispatchEvent(OWNER, TARGET_REPO, sha);
-  }
   return res.status(200).send();
 };
 /**

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -1,10 +1,9 @@
-const latestVersion = require('latest-version');
 const { graphql } = require('@octokit/graphql');
 const { verify } = require('@octokit/webhooks-methods');
 const { Octokit } = require('@octokit/rest');
 const { createAppAuth } = require('@octokit/auth-app');
+const { compare } = require('semver');
 
-const DOC_CHANGES_TYPE = 'doc_changes';
 const {
   GITHUB_TOKEN,
   WEBHOOK_SECRET,
@@ -15,12 +14,69 @@ const {
   CLIENT_SECRET,
 } = process.env;
 
+/**
+ * @param {NodeResult} release
+ */
+const getVersion = (release) => {
+  /**
+   * Electron releases urls have a well-known format. E.g.:
+   * https://github.com/electron/electron/releases/tag/v14.0.0-beta.2
+   * We only need the latest part (i.e. `14.0.0-beta.2`)
+   */
+  return release.url.split('/v').pop();
+};
+
+/**
+ * Transforms a NodeResult into a Release
+ * @param {NodeResult[]} releases
+ */
+const toReleases = (releases) => {
+  const stables = releases.filter((release) => !release.isPrerelease);
+
+  const versions = stables.map((release) => {
+    return getVersion(release);
+  });
+
+  return versions;
+};
+
+const getReleases = async () => {
+  const query = `
+{
+  repository(owner: "electron", name: "electron") {
+    refs(refPrefix: "refs/tags/", first: 1) {
+      nodes {
+        repository {
+          releases(first: 100, orderBy: {field: CREATED_AT, direction: DESC}) {
+            nodes {
+              name
+              url
+              isPrerelease
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+  const graphqlWithAuth = await getAuthenticatedGraphql();
+  const queryResults = await graphqlWithAuth(query);
+
+  const releases = toReleases(
+    queryResults.repository.refs.nodes[0].repository.releases.nodes
+  );
+
+  return releases.sort(compare);
+};
+
 const getLatestInformation = async () => {
-  const version = await latestVersion('electron');
-  const branch = version.replace(/\.\d+\.\d+$/, '-x-y');
+  const releases = await getReleases();
+  const latestVersion = releases.pop();
+  const branch = latestVersion.replace(/\.\d+\.\d+$/, '-x-y');
 
   return {
-    version,
+    version: latestVersion,
     branch,
   };
 };
@@ -107,25 +163,24 @@ const getAuthorization = () => {
 
 /**
  * Sends a `repository_dispatch` event top the given repo `target`
- * with the type `doc_changes` and the given commit `sha` as part
- * of the payload.
+ * with the given type and payload.
  * @param {string} owner The owner of the repo to send the event to
  * @param {string} repo The repo to send the event to
- * @param {string} sha The commit's SHA
+ * @param {string} eventType The type of event_dispatch to use
+ * @param {object} payload The event's payload
  */
-const sendRepositoryDispatchEvent = async (owner, repo, sha) => {
+const sendRepositoryDispatchEvent = async (owner, repo, eventType, payload) => {
   const octokit = new Octokit(getAuthorization());
 
-  console.log(`Sending payload with SHA "${sha}"`);
+  console.log(`Sending payload (${eventType}):
+${JSON.stringify(payload, null, 2)}`);
 
   try {
     await octokit.repos.createDispatchEvent({
       owner,
       repo,
-      event_type: DOC_CHANGES_TYPE,
-      client_payload: {
-        sha,
-      },
+      event_type: eventType,
+      client_payload: payload,
     });
 
     console.log(`Payload sent`);
@@ -154,54 +209,8 @@ const getAuthenticatedGraphql = async () => {
   }
 };
 
-/**
- * For a given `tagName`, returns the associated SHA.
- *
- * @param {string} repository The repository in the form of `owner/name`
- * @param {string} tagName
- * @returns {Promise<string>}
- */
-const getSHAFromTag = async (repository, tagName) => {
-  console.log(`Getting SHA for "${repository}" and "${tagName}"`);
-
-  const [owner, repo] = repository.split('/');
-
-  const parameters = {
-    owner,
-    repo,
-    tagName,
-  };
-
-  const graphqlWithAuth = await getAuthenticatedGraphql();
-
-  const {
-    repository: {
-      release: {
-        tagCommit: { oid },
-      },
-    },
-  } = await graphqlWithAuth(
-    `
-      query shaFromTag($owner: String!, $repo: String!, $tagName: String!) {
-        repository(owner: $owner, name: $repo) {
-          release(tagName: $tagName) {
-            tagCommit {
-              oid
-            }
-          }
-        }
-      }
-    `,
-    parameters
-  );
-
-  console.log(`SHA is ${oid}`);
-  return oid;
-};
-
 module.exports = {
   getLatestInformation,
-  getSHAFromTag,
   sendRepositoryDispatchEvent,
   verifyIntegrity,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -660,11 +660,6 @@
   resolved "https://registry.yarnpkg.com/@octokit/webhooks-types/-/webhooks-types-3.74.0.tgz#f28db8331f1c4460111e8533419d1e8b06edb3a7"
   integrity sha512-yRVaBKRNt22HXwmJ5GpOfXRf98Dsz30Hm+sWoW3tCYl29RWPQMu5q2R5BE10sSqyRzIS2nBteNyHxyzcF+GWew==
 
-"@sindresorhus/is@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
-  integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
-
 "@sindresorhus/is@^4.0.0":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.0.1.tgz#d26729db850fa327b7cacc5522252194404226f5"
@@ -683,13 +678,6 @@
   integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
-
-"@szmarczak/http-timer@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
-  integrity sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
-  dependencies:
-    defer-to-connect "^1.0.1"
 
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.5"
@@ -1200,19 +1188,6 @@ cacheable-lookup@^5.0.3:
   resolved "https://registry.yarnpkg.com/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz#5a6b865b2c44357be3d5ebc2a467b032719a7005"
   integrity sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==
 
-cacheable-request@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-6.1.0.tgz#20ffb8bd162ba4be11e9567d823db651052ca912"
-  integrity sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==
-  dependencies:
-    clone-response "^1.0.2"
-    get-stream "^5.1.0"
-    http-cache-semantics "^4.0.0"
-    keyv "^3.0.0"
-    lowercase-keys "^2.0.0"
-    normalize-url "^4.1.0"
-    responselike "^1.0.2"
-
 cacheable-request@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-7.0.1.tgz#062031c2856232782ed694a257fa35da93942a58"
@@ -1519,24 +1494,12 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
   integrity sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
 
-decompress-response@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
-  integrity sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
-  dependencies:
-    mimic-response "^1.0.0"
-
 decompress-response@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-6.0.0.tgz#ca387612ddb7e104bd16d85aab00d5ecf09c66fc"
   integrity sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==
   dependencies:
     mimic-response "^3.1.0"
-
-deep-extend@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
-  integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
 deep-is@~0.1.3:
   version "0.1.3"
@@ -1547,11 +1510,6 @@ deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
-
-defer-to-connect@^1.0.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
-  integrity sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
 
 defer-to-connect@^2.0.0:
   version "2.0.1"
@@ -1633,11 +1591,6 @@ dotenv@^8.2.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
-
-duplexer3@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
-  integrity sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -2049,7 +2002,7 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
-get-stream@^4.0.0, get-stream@^4.1.0:
+get-stream@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
   integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
@@ -2108,23 +2061,6 @@ got@^11.8.2:
     lowercase-keys "^2.0.0"
     p-cancelable "^2.0.0"
     responselike "^2.0.0"
-
-got@^9.6.0:
-  version "9.6.0"
-  resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
-  integrity sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==
-  dependencies:
-    "@sindresorhus/is" "^0.14.0"
-    "@szmarczak/http-timer" "^1.1.2"
-    cacheable-request "^6.0.0"
-    decompress-response "^3.3.0"
-    duplexer3 "^0.1.4"
-    get-stream "^4.1.0"
-    lowercase-keys "^1.0.1"
-    mimic-response "^1.0.1"
-    p-cancelable "^1.0.0"
-    to-readable-stream "^1.0.0"
-    url-parse-lax "^3.0.0"
 
 graceful-fs@^4.2.4:
   version "4.2.6"
@@ -2305,11 +2241,6 @@ inherits@2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
-
-ini@~1.3.0:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
-  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -2965,11 +2896,6 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-json-buffer@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
-  integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
-
 json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
@@ -3045,13 +2971,6 @@ jws@^3.2.2:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
-keyv@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
-  integrity sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==
-  dependencies:
-    json-buffer "3.0.0"
-
 keyv@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.0.3.tgz#4f3aa98de254803cafcd2896734108daa35e4254"
@@ -3087,13 +3006,6 @@ kleur@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
-
-latest-version@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
-  integrity sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==
-  dependencies:
-    package-json "^6.3.0"
 
 leven@^3.1.0:
   version "3.1.0"
@@ -3159,11 +3071,6 @@ lodash@^4.17.19, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-lowercase-keys@^1.0.0, lowercase-keys@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
-  integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
 lowercase-keys@^2.0.0:
   version "2.0.0"
@@ -3277,7 +3184,7 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-mimic-response@^1.0.0, mimic-response@^1.0.1:
+mimic-response@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
@@ -3526,11 +3433,6 @@ original@^1.0.0:
   dependencies:
     url-parse "^1.4.3"
 
-p-cancelable@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
-  integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
-
 p-cancelable@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-2.1.1.tgz#aab7fbd416582fa32a3db49859c122487c5ed2cf"
@@ -3564,16 +3466,6 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
-
-package-json@^6.3.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/package-json/-/package-json-6.5.0.tgz#6feedaca35e75725876d0b0e64974697fed145b0"
-  integrity sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==
-  dependencies:
-    got "^9.6.0"
-    registry-auth-token "^4.0.0"
-    registry-url "^5.0.0"
-    semver "^6.2.0"
 
 parse-json@^5.0.0:
   version "5.2.0"
@@ -3663,11 +3555,6 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
-
-prepend-http@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
-  integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
 
 prettier@^2.3.0:
   version "2.3.0"
@@ -3760,16 +3647,6 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-rc@^1.2.8:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
-  integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
-  dependencies:
-    deep-extend "^0.6.0"
-    ini "~1.3.0"
-    minimist "^1.2.0"
-    strip-json-comments "~2.0.1"
-
 react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
@@ -3810,20 +3687,6 @@ regex-not@^1.0.0, regex-not@^1.0.2:
   dependencies:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
-
-registry-auth-token@^4.0.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-4.2.1.tgz#6d7b4006441918972ccd5fedcd41dc322c79b250"
-  integrity sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==
-  dependencies:
-    rc "^1.2.8"
-
-registry-url@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/registry-url/-/registry-url-5.1.0.tgz#e98334b50d5434b81136b44ec638d9c2009c5009"
-  integrity sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==
-  dependencies:
-    rc "^1.2.8"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -3927,13 +3790,6 @@ resolve@^1.10.0, resolve@^1.18.1:
     is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
-responselike@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
-  integrity sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=
-  dependencies:
-    lowercase-keys "^1.0.0"
-
 responselike@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/responselike/-/responselike-2.0.0.tgz#26391bcc3174f750f9a79eacc40a12a5c42d7723"
@@ -4007,7 +3863,7 @@ saxes@^5.0.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -4325,11 +4181,6 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
-
 superagent@^5.0.2:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/superagent/-/superagent-5.3.1.tgz#d62f3234d76b8138c1320e90fa83dc1850ccabf1"
@@ -4412,11 +4263,6 @@ to-object-path@^0.3.0:
   integrity sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=
   dependencies:
     kind-of "^3.0.2"
-
-to-readable-stream@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/to-readable-stream/-/to-readable-stream-1.0.0.tgz#ce0aa0c2f3df6adf852efb404a783e77c0475771"
-  integrity sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==
 
 to-regex-range@^2.1.0:
   version "2.1.1"
@@ -4578,13 +4424,6 @@ urix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
-
-url-parse-lax@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
-  integrity sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
-  dependencies:
-    prepend-http "^2.0.0"
 
 url-parse@^1.4.3:
   version "1.5.1"


### PR DESCRIPTION
This change addresses 2 changes:

1. Removed the handling of a new release. Currently we do not seem to be
   processing correctly that event (or even receiving it). Because we do
   not have access to the payloads it is faster to work with `push`
   instead of debugging because we are going to have versioned docs.
2. The other change is to add the `event_type` `doc_changes_previous`.
   This type is used when the `push` happens in a branch that is not the
   latest stable one. Additionally it changes the logic to find the
   latest version by using a GraphQL query to get the latest releases
   instead of relying on npm. The reason is that there is a delay of
   up to 2 hours between a GitHub release and the moment it is published
   in npm.