### PR TITLE
chore: rename Electron website repo

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -111,7 +111,7 @@ describe('webhook server', () => {
       expect(utils.sendRepositoryDispatchEvent).toBeCalledTimes(1);
       expect(utils.sendRepositoryDispatchEvent).toHaveBeenCalledWith(
         'electron',
-        'electronjs.org-new',
+        'website',
         'doc_changes_branches',
         { branch: '1-x-y', sha: 'd07ca4f716c62d6f4a481a74b54b448b95bbe3d9' }
       );
@@ -135,14 +135,14 @@ describe('webhook server', () => {
       expect(utils.sendRepositoryDispatchEvent).toBeCalledTimes(2);
       expect(utils.sendRepositoryDispatchEvent).toHaveBeenCalledWith(
         'electron',
-        'electronjs.org-new',
+        'website',
         'doc_changes',
         { branch: '12-x-y', sha: 'd07ca4f716c62d6f4a481a74b54b448b95bbe3d9' }
       );
 
       expect(utils.sendRepositoryDispatchEvent).toHaveBeenCalledWith(
         'electron',
-        'electronjs.org-new',
+        'website',
         'doc_changes_branches',
         { branch: '12-x-y', sha: 'd07ca4f716c62d6f4a481a74b54b448b95bbe3d9' }
       );

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 This project handles the webhooks from `electron/electron` and filters them
 to dispatch only the appropriate ones as `repository_dispatch` events to
-`electron/electronjs.org-new` ("that repo").
+`electron/website` ("that repo").
 
 These events are used to let that repo know there have been documentation changes.
 
@@ -74,7 +74,7 @@ Go [here to create a new GitHub App][github app] and use the following data (if 
 mentioned, you can leave the defaults):
 
 - GitHub App name: Electron Website Updater
-- Homepage URL: https://github.com/OWNER/electronjs.org-new
+- Homepage URL: https://github.com/OWNER/website
 - Webhook: deactivated
 - Repository permissions:
   - Contents - Read & write

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -10,7 +10,7 @@ const {
 
 const OWNER = process.env.OWNER || 'electron';
 const SOURCE_REPO = `electron`;
-const TARGET_REPO = `electronjs.org-new`;
+const TARGET_REPO = `website`;
 const EVENT_TYPE = {
   CURRENT: 'doc_changes',
   BRANCHES: 'doc_changes_branches',


### PR DESCRIPTION
Since we launched the new `electronjs.org` website, we're dropping the `electronjs.org-new` repo name.