### PR TITLE
chore: bump dependencies to clear audit

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -9,7 +9,7 @@ utils.getLatestInformation = mock.fn(() =>
   Promise.resolve({
     version: '12.0.6',
     branch: '12-x-y',
-  })
+  }),
 );
 
 const { start } = require('../index');
@@ -68,7 +68,7 @@ describe('webhook server', () => {
 
   it('returns a 404 if it does not exists', async () => {
     const response = await fetch(
-      `http://localhost:${server.port}/do-not-exists`
+      `http://localhost:${server.port}/do-not-exists`,
     );
 
     assert.strictEqual(response.status, 404);
@@ -114,7 +114,7 @@ describe('webhook server', () => {
           'website',
           'doc_changes_branches',
           { branch: '1-x-y', sha: 'd07ca4f716c62d6f4a481a74b54b448b95bbe3d9' },
-        ]
+        ],
       );
     });
 
@@ -139,7 +139,7 @@ describe('webhook server', () => {
           'website',
           'doc_changes',
           { branch: '12-x-y', sha: 'd07ca4f716c62d6f4a481a74b54b448b95bbe3d9' },
-        ]
+        ],
       );
 
       assert.deepStrictEqual(
@@ -149,7 +149,7 @@ describe('webhook server', () => {
           'website',
           'doc_changes_branches',
           { branch: '12-x-y', sha: 'd07ca4f716c62d6f4a481a74b54b448b95bbe3d9' },
-        ]
+        ],
       );
     });
 

--- a/package.json
+++ b/package.json
@@ -22,14 +22,14 @@
     "@octokit/webhooks-methods": "^1.0.0",
     "body-parser": "^1.20.3",
     "dotenv-safe": "^8.2.0",
-    "express": "^4.21.0",
-    "semver": "^6.3.1"
+    "express": "^4.21.1",
+    "semver": "^7.6.3"
   },
   "devDependencies": {
     "@octokit/webhooks-types": "^3.71.2",
     "@types/body-parser": "^1.19.5",
     "@types/express": "^4.17.21",
-    "prettier": "^2.3.0",
-    "smee-client": "^2.0.1"
+    "prettier": "^3.3.3",
+    "smee-client": "^2.0.4"
   }
 }

--- a/routes/webhook.js
+++ b/routes/webhook.js
@@ -128,7 +128,7 @@ const pushHandler = async (req, res) => {
         {
           sha: payload.after,
           branch: payload.ref.replace('refs/heads/', ''),
-        }
+        },
       );
     }
   }

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -64,7 +64,7 @@ const getReleases = async () => {
   const queryResults = await graphqlWithAuth(query);
 
   const releases = toReleases(
-    queryResults.repository.refs.nodes[0].repository.releases.nodes
+    queryResults.repository.refs.nodes[0].repository.releases.nodes,
   );
 
   return releases.sort(compare);

--- a/yarn.lock
+++ b/yarn.lock
@@ -358,10 +358,10 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
-cookie@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
-  integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
+cookie@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.1.tgz#2f73c42142d5d5cf71310a74fc4ae61670e5dbc9"
+  integrity sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==
 
 debug@2.6.9:
   version "2.6.9"
@@ -455,17 +455,17 @@ eventsource@^2.0.2:
   resolved "https://registry.yarnpkg.com/eventsource/-/eventsource-2.0.2.tgz#76dfcc02930fb2ff339520b6d290da573a9e8508"
   integrity sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==
 
-express@^4.21.0:
-  version "4.21.0"
-  resolved "https://registry.yarnpkg.com/express/-/express-4.21.0.tgz#d57cb706d49623d4ac27833f1cbc466b668eb915"
-  integrity sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==
+express@^4.21.1:
+  version "4.21.1"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.21.1.tgz#9dae5dda832f16b4eec941a4e44aa89ec481b281"
+  integrity sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==
   dependencies:
     accepts "~1.3.8"
     array-flatten "1.1.1"
     body-parser "1.20.3"
     content-disposition "0.5.4"
     content-type "~1.0.4"
-    cookie "0.6.0"
+    cookie "0.7.1"
     cookie-signature "1.0.6"
     debug "2.6.9"
     depd "2.0.0"
@@ -729,10 +729,10 @@ path-to-regexp@0.1.10:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.10.tgz#67e9108c5c0551b9e5326064387de4763c4d5f8b"
   integrity sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==
 
-prettier@^2.3.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.3.0.tgz#b6a5bf1284026ae640f17f7ff5658a7567fc0d18"
-  integrity sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==
+prettier@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
+  integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
 
 proxy-addr@~2.0.7:
   version "2.0.7"
@@ -774,17 +774,17 @@ safe-buffer@5.2.1, safe-buffer@^5.0.1:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-semver@^6.3.1:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
 semver@^7.3.8:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.6.3:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
+  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
 send@0.19.0:
   version "0.19.0"
@@ -842,10 +842,10 @@ side-channel@^1.0.6:
     get-intrinsic "^1.2.4"
     object-inspect "^1.13.1"
 
-smee-client@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/smee-client/-/smee-client-2.0.1.tgz#348a644c3499cc7687fcb42fbbaeeeb3211a365d"
-  integrity sha512-s2+eG9vNMWQQvu8Jz+SfAiihpYsmaMtcyPnHtBuZEhaAAQOQV63xSSL9StWv2p08xKgvSC8pEZ28rXoy41FhLg==
+smee-client@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/smee-client/-/smee-client-2.0.4.tgz#796d44e30104d0d222140b8d38cedde89855da7b"
+  integrity sha512-RxXCs0mfaxpI8JF4SeTM51XtRiprzW5g20HVt4aTQ36EB+RaN0aj0m/4EbXLGdfPlqahQ09d3UnJYmALN2CbYw==
   dependencies:
     commander "^12.0.0"
     eventsource "^2.0.2"


### PR DESCRIPTION
Only one that needed to be bumped to clear the audit was `express`, but also bumps `prettier` and `semver` to stay more up-to-date.